### PR TITLE
Feature/ENG-2808 moving requestbin to kubernetes

### DIFF
--- a/k8s.yaml
+++ b/k8s.yaml
@@ -1,0 +1,84 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: requestbin
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: requestbin
+spec:
+  selector:
+    app: redis
+  ports:
+  - port: 6379
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: requestbin
+  labels:
+    app: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - name: redis
+        image: redis:4.0@sha256:c389a35832492c42f4719776471f9a42d2fc5a8ba0077ba25746626b09eab880
+        ports:
+        - containerPort: 6379
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: requestbin
+  namespace: requestbin
+spec:
+  type: NodePort
+  selector:
+    app: requestbin
+  ports:
+  - port: 80
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: requestbin
+  namespace: requestbin
+  labels:
+    app: requestbin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: requestbin
+  template:
+    metadata:
+      labels:
+        app: requestbin
+    spec:
+      containers:
+      - name: requestbin
+        image: crccheck/requestbin@sha256:a3dfaa2c2ace47cdcd2add65621e8ad343e5b58819878f6a42f80fd25e9321e5
+        ports:
+        - containerPort: 80
+        env:
+        - name: REDIS_URL
+          value: redis://redis:6379/0

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -53,7 +53,7 @@ spec:
   selector:
     app: requestbin
   ports:
-  - port: 80
+  - port: 8000
 
 ---
 
@@ -76,9 +76,42 @@ spec:
     spec:
       containers:
       - name: requestbin
-        image: crccheck/requestbin@sha256:a3dfaa2c2ace47cdcd2add65621e8ad343e5b58819878f6a42f80fd25e9321e5
+        image: '819234847174.dkr.ecr.us-east-1.amazonaws.com/requestbin:latest'
         ports:
-        - containerPort: 80
+          - containerPort: 8000
         env:
-        - name: REDIS_URL
-          value: redis://redis:6379/0
+          - name: REALM
+            value: prod
+          - name: REDIS_URL
+            value: redis://redis:6379/0
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    certmanager.k8s.io/acme-challenge-type: dns01
+    certmanager.k8s.io/acme-dns01-provider: dns
+    certmanager.k8s.io/cluster-issuer: letsencrypt-production-dns
+    external-dns.alpha.kubernetes.io/hostname: requestbin.communitysift.com
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/ingress.class: nginx
+  labels:
+    app.kubernetes.io/managed-by: spinnaker
+    app.kubernetes.io/name: requestbin
+  name: requestbin
+  namespace: requestbin
+spec:
+  rules:
+    - host: requestbin.communitysift.com
+      http:
+        paths:
+          - backend:
+              serviceName: requestbin
+              servicePort: 8000
+            path: /
+  tls:
+    - hosts:
+        - requestbin.communitysift.com
+      secretName: requestbin-communitysift-com


### PR DESCRIPTION
requestbin.communitysift.com changed from a standalone instance to running in the EUON Kubernetes cluster